### PR TITLE
Fix: createArchivePages

### DIFF
--- a/createPages/createArchivePages.js
+++ b/createPages/createArchivePages.js
@@ -9,7 +9,7 @@ async function createArchivePages({
   archiveContentType,
   id,
   component,
-  uri,
+  slug,
   contentNodes,
   graphql,
   actions,
@@ -66,7 +66,7 @@ async function createArchivePages({
           // we want the first page to be the uri of the archive page. example: "/blog/"
           // and any additional pages to be numbered. example: "/blog/2"
 
-          return page === 1 ? uri : `${uri}${page}`
+          return page === 1 ? `/${slug}/` : `/${slug}/${page}`
         }
 
         return null

--- a/createPages/createContentPages.js
+++ b/createPages/createContentPages.js
@@ -15,7 +15,7 @@ const createContentPages = async ({
 }) =>
   Promise.all(
     contentNodes.map(async contentNode => {
-      const { id, uri, nodeType } = contentNode
+      const { id, uri, slug, nodeType } = contentNode
 
       const isPageExcluded = getPageExclusionStatus({ contentNode, options })
 
@@ -24,7 +24,7 @@ const createContentPages = async ({
       }
 
       const archive = contentTypes.find(contentType => {
-        if (contentType.archivePath === uri) {
+        if (contentType.archivePath === `/${slug}/`) {
           if (uri === "/" && !contentType.isFrontPage) {
             // if no blog page exists, the archivePath defaults to "/"
             // even if the home page is already set to a different page
@@ -49,13 +49,13 @@ const createContentPages = async ({
       const seo = await getContentSeo({ id, nodeType, graphql })
 
       if (!!archive) {
-        reporter.verbose(`Creating ${archive.graphqlSingleName} at ${uri}`)
+        reporter.verbose(`Creating ${archive.graphqlSingleName} at /${slug}/`)
 
         await createArchivePages({
           archiveContentType: archive.graphqlSingleName,
           id,
           component: path.resolve(contentTypeTemplatePath),
-          uri,
+          slug,
           contentNodes,
           graphql,
           actions,

--- a/createPages/getContentNodes.js
+++ b/createPages/getContentNodes.js
@@ -6,6 +6,7 @@ async function getContentNodes({ graphql, reporter }) {
           __typename
           id
           uri
+          slug
           nodeType
           template {
             templateName


### PR DESCRIPTION
Since WPGraphQL v1.10.0, archives return null for uri and so archive pages weren't being created. This PR replaces uri with slug instead.

It probably still needs to be tested a bit more, but for what I need it works as a good replacement.

Related Issue: #1 